### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/v1.9-alpine.yml
+++ b/.github/workflows/v1.9-alpine.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         KONG_BASE: kong:2.5.0-alpine
         PLUGINS: --server=http://luarocks.org/manifests/moesif kong-plugin-moesif 1.0.9-1


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore